### PR TITLE
Changes function name typo

### DIFF
--- a/src/instagram.py
+++ b/src/instagram.py
@@ -112,7 +112,7 @@ class Instagram:
             pc.print("Please re-check credentials again in ./creds/insta.yml file :) ", style='orange1')   
             # login exired
             # login again
-            self.api = AppClient(auto_patch=True, authentication=True, username=user,password=passwd, on_login=lambda x: self.on_login_callback(x, settings_file))
+            self.api = AppClient(auto_patch=True, authentication=True, username=user,password=passwd, on_login=lambda x: self.onlogin_callback(x, settings_file))
             
         except ClientError as err:
             e = json.loads(err.error_response)


### PR DESCRIPTION
For expired cookies, the response should be onlogin_callback rather than on_login_callback